### PR TITLE
Improve documentation, tests and connection handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+
+# pytest
+.pytest_cache/
+
+# environment files
+.env

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This project shows how to use **pyATS/Genie** with **Unicon mock devices** to te
 
 ## Setup
 ```bash
-cd evpn-mock
-python3 -m venv .venv && source .venv/bin/activate
+git clone <repo url>
+cd pyats_mock-devices
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
@@ -14,6 +16,11 @@ pip install -r requirements.txt
 pyats run job jobs/basic_job.py
 # or
 pyats run testbed-file testbed.yaml tests/test_evpn_mock.py
+```
+
+## Run the unit tests
+```bash
+pytest
 ```
 
 ## Run the Blitz example

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyats~=23.9
 genie~=23.9
 unicon~=23.9
 unicon.plugins~=23.9
+pytest

--- a/tests/helpers/validators.py
+++ b/tests/helpers/validators.py
@@ -1,4 +1,13 @@
 def all_bgp_neighbors_established(parsed_summary):
+    """Check that all BGP EVPN neighbors are in the *Established* state.
+
+    Args:
+        parsed_summary (dict): Output from parsing ``show bgp l2vpn evpn summary``.
+
+    Returns:
+        tuple[bool, str]: ``(True, "")`` if all peers are established, otherwise
+        ``(False, message)`` describing the peers in a non-established state.
+    """
     if not parsed_summary or 'vrf' not in parsed_summary:
         return False, "No VRF data in BGP EVPN summary"
     bad = []
@@ -9,6 +18,15 @@ def all_bgp_neighbors_established(parsed_summary):
     return (not bad, "; ".join(bad))
 
 def vnis_active(parsed_nve_vni):
+    """Verify that all VNIs in the ``show nve vni`` output are up.
+
+    Args:
+        parsed_nve_vni (dict): Output from parsing ``show nve vni``.
+
+    Returns:
+        tuple[bool, str]: ``(True, "")`` if every VNI is up, otherwise
+        ``(False, message)`` listing the VNIs that are not up.
+    """
     down = []
     for vni, data in parsed_nve_vni.get('vni', {}).items():
         if data.get('vni_state','').lower() != 'up':

--- a/tests/test_evpn_mock.py
+++ b/tests/test_evpn_mock.py
@@ -1,6 +1,10 @@
+import logging
+
 from pyats import aetest
 from genie.testbed import load
 from tests.helpers.validators import all_bgp_neighbors_established, vnis_active
+
+log = logging.getLogger(__name__)
 
 class CommonSetup(aetest.CommonSetup):
     @aetest.subsection
@@ -8,7 +12,10 @@ class CommonSetup(aetest.CommonSetup):
         self.parent.parameters['testbed'] = load(testbed) if isinstance(testbed, str) else testbed
         tb = self.parent.parameters['testbed']
         for dev in tb.devices.values():
-            dev.connect(log_stdout=False)
+            try:
+                dev.connect(log_stdout=False)
+            except Exception as exc:
+                log.error("Failed to connect to %s: %s", dev.name, exc)
 
 class BgpEvpnChecks(aetest.Testcase):
     @aetest.test

--- a/tests/unit/test_validators.py
+++ b/tests/unit/test_validators.py
@@ -1,0 +1,46 @@
+import pytest
+from genie.testbed import load
+from tests.helpers.validators import (
+    all_bgp_neighbors_established,
+    vnis_active,
+)
+
+
+@pytest.fixture(scope="module")
+def leaf1():
+    tb = load("testbed.yaml")
+    dev = tb.devices["leaf1"]
+    dev.connect(log_stdout=False)
+    yield dev
+    dev.disconnect()
+
+
+@pytest.fixture(scope="module")
+def leaf1_bad():
+    tb = load("testbed.yaml")
+    bad_cmd = tb.devices["leaf1"].connections.cli.command.replace(
+        "leaf1.yaml", "leaf1_bad.yaml"
+    )
+    tb.devices["leaf1"].connections.cli.command = bad_cmd
+    dev = tb.devices["leaf1"]
+    dev.connect(log_stdout=False)
+    yield dev
+    dev.disconnect()
+
+
+def test_bgp_neighbors_up(leaf1):
+    parsed = leaf1.parse("show bgp l2vpn evpn summary")
+    ok, msg = all_bgp_neighbors_established(parsed)
+    assert ok, msg
+
+
+def test_bgp_neighbor_failure(leaf1_bad):
+    parsed = leaf1_bad.parse("show bgp l2vpn evpn summary")
+    ok, msg = all_bgp_neighbors_established(parsed)
+    assert not ok and "state" in msg
+
+
+def test_vni_down_detected(leaf1_bad):
+    parsed = leaf1_bad.parse("show nve vni")
+    ok, msg = vnis_active(parsed)
+    assert not ok and "VNI(s) not up" in msg


### PR DESCRIPTION
## Summary
- fix README setup path and include basic pytest instructions
- document validator helpers and add offline unit tests
- guard device connections with error logging and ignore virtualenv artifacts

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pyats~=23.9)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pyats')*

------
https://chatgpt.com/codex/tasks/task_e_68964bb1b1748324872b5dd773dcb3b0